### PR TITLE
base: add gettext package

### DIFF
--- a/build/setup-base.sh
+++ b/build/setup-base.sh
@@ -8,6 +8,7 @@ yum install -y \
     diffutils \
     file \
     findutils \
+    gettext \
     gcc \
     gcc-c++ \
     gpgme \


### PR DESCRIPTION
gettext is very useful and actually used by many scripts in CI, it
provides envsubst which helps to substitutes environment variables
in shell format strings.

This patch installs the package in the base script.
