### PR TITLE
Trigger rebuild (for `gosec` update)

### DIFF
--- a/.trigger-openshift-ci
+++ b/.trigger-openshift-ci
@@ -1,1 +1,1 @@
-stolostron/build-harness-extensions@2ce1b35c0098a407dda410ea9dcd66a7263b68b7
+stolostron/build-harness-extensions@2ce1b35c0098a407dda410ea9dcd66a7263b68b7 rebuild


### PR DESCRIPTION
The purpose is to pull a newer version of `gosec` released about a week ago with important fixes for linting skips that were previously ignored.

The installation of `gosec` grabs the most recent release from Github, so there's no need for any update on the harness extensions.