### PR TITLE
Add a Go 1.22 builder and update 1.21 and 1.20

### DIFF
--- a/Dockerfile.go1.21-linux
+++ b/Dockerfile.go1.21-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.21.6 \
+    GOVERSION=1.21.10 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \

--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.20.14 \
+    GOVERSION=1.22.3 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \


### PR DESCRIPTION
(1.20 is EOL but we might as well use the last version.)