### PR TITLE
Add a RHEL8 builder image

### DIFF
--- a/Dockerfile.go1.22-linux-rhel8
+++ b/Dockerfile.go1.22-linux-rhel8
@@ -1,0 +1,26 @@
+FROM registry.access.redhat.com/ubi8/ubi
+
+ENV GOPATH=/go \
+    GOVERSION=1.22.3 \
+    CM_VERSION=v1.0.9 \
+    GOCACHE=/go/pkg/cache \
+    SONAR_USER_HOME=/opt/sonar/.sonar \
+    PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin
+
+COPY build/* /usr/local/bin/
+COPY kind/* /opt/kind/
+
+RUN setup-base.sh
+RUN setup-jq.sh
+RUN setup-yq.sh
+RUN setup-yamllint.sh
+RUN setup-oc.sh
+RUN setup-httpd-tools.sh
+RUN setup-build-harness.sh
+RUN setup-sonar.sh
+RUN setup-go.sh
+RUN setup-dep.sh
+RUN setup-cm-cli.sh
+RUN setup-gosec.sh
+RUN setup-kubebuilder.sh
+RUN setup-terraform.sh


### PR DESCRIPTION
For portability and FIPS, we have a need to have a RHEL8 image to build binaries compatible with other systems.