### PR TITLE
Add a Go 1.23 build image

### DIFF
--- a/Dockerfile.go1.21-linux
+++ b/Dockerfile.go1.21-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.21.10 \
+    GOVERSION=1.21.13 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \

--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.22.10 \
+    GOVERSION=1.23.4 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \


### PR DESCRIPTION
... and update the Go 1.21 and 1.22 images to the latest Go version in the respective series.