### PR TITLE
Bump Go v1.22 version to latest

### DIFF
--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.22.10 \
+    GOVERSION=1.22.12 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \


### PR DESCRIPTION
Addresses CVE-2025-22866