### PR TITLE
Bump Go compilers

### DIFF
--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.22.10 \
+    GOVERSION=1.22.12 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \

--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.23.4 \
+    GOVERSION=1.23.9 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.24.2 \
+    GOVERSION=1.24.3 \
     CM_VERSION=v1.0.15 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \


### PR DESCRIPTION
This bumps to 1.22.12 (the last 1.22 compiler), 1.23.9, and 1.24.3. These fix a number of CVEs.