### PR TITLE
Bump to Go 1.23.10 and 1.24.4

### DIFF
--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.23.9 \
+    GOVERSION=1.23.10 \
     CM_VERSION=v1.0.9 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -1,7 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV GOPATH=/go \
-    GOVERSION=1.24.3 \
+    GOVERSION=1.24.4 \
     CM_VERSION=v1.0.15 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \


### PR DESCRIPTION
This fixes a number of security issues in the standard library.