### PR TITLE
fix: set Go dir permissions; tweak: consolidate go version parsing

### DIFF
--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -21,3 +21,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
+RUN chmod -R a+rwx /go

--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -21,3 +21,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
+RUN chmod -R a+rwx /go

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -21,3 +21,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
+RUN chmod -R a+rwx /go

--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -21,3 +21,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
+RUN chmod -R a+rwx /go

--- a/Dockerfile.nodejs16-linux
+++ b/Dockerfile.nodejs16-linux
@@ -10,7 +10,7 @@ COPY build/* /usr/local/bin/
 COPY yarn-source /yarn-source
 
 RUN setup-base.sh
-RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | head -1 | sed 's/go//') \
+RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | sed '1s/go//;q') \
     setup-go.sh
 RUN setup-jq.sh
 RUN setup-yq.sh

--- a/Dockerfile.nodejs16-linux
+++ b/Dockerfile.nodejs16-linux
@@ -21,4 +21,5 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-node.sh
 RUN setup-yarn.sh /yarn-source
+RUN chmod -R a+rwx /go
 RUN cleanup-node.sh

--- a/Dockerfile.nodejs18-linux
+++ b/Dockerfile.nodejs18-linux
@@ -10,7 +10,7 @@ COPY build/* /usr/local/bin/
 COPY yarn-source /yarn-source
 
 RUN setup-base.sh
-RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | head -1 | sed 's/go//') \
+RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | sed '1s/go//;q') \
     setup-go.sh
 RUN setup-jq.sh
 RUN setup-yq.sh

--- a/Dockerfile.nodejs18-linux
+++ b/Dockerfile.nodejs18-linux
@@ -21,4 +21,5 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-node.sh
 RUN setup-yarn.sh /yarn-source
+RUN chmod -R a+rwx /go
 RUN cleanup-node.sh

--- a/Dockerfile.nodejs20-linux
+++ b/Dockerfile.nodejs20-linux
@@ -10,7 +10,7 @@ COPY build/* /usr/local/bin/
 COPY yarn-source /yarn-source
 
 RUN setup-base.sh
-RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | head -1 | sed 's/go//') \
+RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | sed '1s/go//;q') \
     setup-go.sh
 RUN setup-jq.sh
 RUN setup-yq.sh

--- a/Dockerfile.nodejs20-linux
+++ b/Dockerfile.nodejs20-linux
@@ -21,4 +21,5 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-node.sh
 RUN setup-yarn.sh /yarn-source
+RUN chmod -R a+rwx /go
 RUN cleanup-node.sh

--- a/build/setup-go.sh
+++ b/build/setup-go.sh
@@ -12,7 +12,6 @@ elif [[ "$ARCH" == "aarch64" ]]; then
 fi
 
 mkdir -p /go/{bin,pkg,src} /go/pkg/cache /opt/go
-chmod -R a+rwx /go
 cd /opt/go
 wget --progress=dot:mega "https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz"
 tar -C /usr/local -xzf "go${GOVERSION}.${OS}-${ARCH}.tar.gz"


### PR DESCRIPTION
- Fixes permissions for the Go cache since previously permissions were set at the end of the build after the cache had been populated.
- Updates to use a consolidated `sed` command for latest Go version parsing in the NodeJS builds

Related to:
- https://github.com/stolostron/image-builder/pull/152