### PR TITLE
setup-yq: set `GOBIN` to correct location

### DIFF
--- a/build/setup-yq.sh
+++ b/build/setup-yq.sh
@@ -13,4 +13,4 @@ if [ "${found_module}" != "${module}" ]; then
 fi
 
 # Install yq
-GOBIN=/usr/local/ go install "${module}@latest"
+GOBIN=/usr/local/bin/ go install "${module}@latest"


### PR DESCRIPTION
`GOBIN` was incorrectly set to `/usr/local/` rather than `/usr/local/bin` causing yq not to be found.