### PR TITLE
fix: restore `cm-cli`; set `HOME=/tmp`

### DIFF
--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -15,6 +15,8 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-cm-cli.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -23,5 +23,6 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
+RUN setup-setup-envtest.sh
 RUN setup-terraform.sh
 RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.22-linux
+++ b/Dockerfile.go1.22-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
-ENV GOPATH=/go \
+ENV HOME=/tmp \
+    GOPATH=/go \
     GOVERSION=1.22.12 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -23,4 +24,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -15,6 +15,8 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-cm-cli.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -23,5 +23,6 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
+RUN setup-setup-envtest.sh
 RUN setup-terraform.sh
 RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.23-linux
+++ b/Dockerfile.go1.23-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
-ENV GOPATH=/go \
+ENV HOME=/tmp \
+    GOPATH=/go \
     GOVERSION=1.23.12 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -23,4 +24,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -15,6 +15,8 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-cm-cli.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
-ENV GOPATH=/go \
+ENV HOME=/tmp \
+    GOPATH=/go \
     GOVERSION=1.24.7 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -23,4 +24,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -23,5 +23,6 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
+RUN setup-setup-envtest.sh
 RUN setup-terraform.sh
 RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.24-linux
+++ b/Dockerfile.go1.24-linux
@@ -13,6 +13,7 @@ COPY kind/* /opt/kind/
 RUN setup-base.sh
 RUN setup-go.sh
 RUN setup-jq.sh
+RUN check-go.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh

--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -15,6 +15,7 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -22,5 +22,6 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
+RUN setup-setup-envtest.sh
 RUN setup-terraform.sh
 RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
-ENV GOPATH=/go \
+ENV HOME=/tmp \
+    GOPATH=/go \
     GOVERSION=1.25.1 \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -22,4 +23,4 @@ RUN setup-sonar.sh
 RUN setup-gosec.sh
 RUN setup-kubebuilder.sh
 RUN setup-terraform.sh
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}

--- a/Dockerfile.go1.25-linux
+++ b/Dockerfile.go1.25-linux
@@ -13,6 +13,7 @@ COPY kind/* /opt/kind/
 RUN setup-base.sh
 RUN setup-go.sh
 RUN setup-jq.sh
+RUN check-go.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh

--- a/Dockerfile.nodejs16-linux
+++ b/Dockerfile.nodejs16-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 ENV NODE_VERSION=16 \
+    HOME=/tmp \
     GOPATH=/go \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -23,5 +24,5 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-node.sh
 RUN setup-yarn.sh /yarn-source
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}
 RUN cleanup-node.sh

--- a/Dockerfile.nodejs16-linux
+++ b/Dockerfile.nodejs16-linux
@@ -16,6 +16,8 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-cm-cli.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.nodejs18-linux
+++ b/Dockerfile.nodejs18-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi8/ubi
 
 ENV NODE_VERSION=18 \
+    HOME=/tmp \
     GOPATH=/go \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -23,5 +24,5 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-node.sh
 RUN setup-yarn.sh /yarn-source
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}
 RUN cleanup-node.sh

--- a/Dockerfile.nodejs18-linux
+++ b/Dockerfile.nodejs18-linux
@@ -16,6 +16,8 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-cm-cli.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.nodejs20-linux
+++ b/Dockerfile.nodejs20-linux
@@ -1,6 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
 ENV NODE_VERSION=20 \
+    HOME=/tmp \
     GOPATH=/go \
     GOCACHE=/go/pkg/cache \
     SONAR_USER_HOME=/opt/sonar/.sonar \
@@ -23,5 +24,5 @@ RUN setup-build-harness.sh
 RUN setup-sonar.sh
 RUN setup-node.sh
 RUN setup-yarn.sh /yarn-source
-RUN chmod -R a+rwx /go
+RUN chmod -R a+rwx /{go,tmp}
 RUN cleanup-node.sh

--- a/Dockerfile.nodejs20-linux
+++ b/Dockerfile.nodejs20-linux
@@ -16,6 +16,8 @@ RUN setup-jq.sh
 RUN setup-yq.sh
 RUN setup-yamllint.sh
 RUN setup-oc.sh
+RUN setup-cm-cli.sh
+RUN setup-clusteradm.sh
 RUN setup-httpd-tools.sh
 RUN setup-build-harness.sh
 RUN setup-sonar.sh

--- a/Dockerfile.nodejs22-linux
+++ b/Dockerfile.nodejs22-linux
@@ -1,0 +1,27 @@
+FROM registry.access.redhat.com/ubi9/ubi
+
+ENV NODE_VERSION=22 \
+    HOME=/tmp \
+    GOPATH=/go \
+    GOCACHE=/go/pkg/cache \
+    SONAR_USER_HOME=/opt/sonar/.sonar \
+    PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin:/yarn-source/node_modules/.bin
+
+COPY build/* /usr/local/bin/
+COPY yarn-source /yarn-source
+
+RUN setup-base.sh
+RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | sed '1s/go//;q') \
+    setup-go.sh
+RUN setup-jq.sh
+RUN setup-yq.sh
+RUN setup-yamllint.sh
+RUN setup-oc.sh
+RUN setup-clusteradm.sh
+RUN setup-httpd-tools.sh
+RUN setup-build-harness.sh
+RUN setup-sonar.sh
+RUN setup-node.sh
+RUN setup-yarn.sh /yarn-source
+RUN chmod -R a+rwx /{go,tmp}
+RUN cleanup-node.sh

--- a/Dockerfile.nodejs24-linux
+++ b/Dockerfile.nodejs24-linux
@@ -1,0 +1,27 @@
+FROM registry.access.redhat.com/ubi9/ubi
+
+ENV NODE_VERSION=24 \
+    HOME=/tmp \
+    GOPATH=/go \
+    GOCACHE=/go/pkg/cache \
+    SONAR_USER_HOME=/opt/sonar/.sonar \
+    PATH=/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/local/go/bin:/opt/sonar/bin:/usr/local/kubebuilder/bin:/yarn-source/node_modules/.bin
+
+COPY build/* /usr/local/bin/
+COPY yarn-source /yarn-source
+
+RUN setup-base.sh
+RUN GOVERSION=$(curl -s https://go.dev/VERSION?m=text | sed '1s/go//;q') \
+    setup-go.sh
+RUN setup-jq.sh
+RUN setup-yq.sh
+RUN setup-yamllint.sh
+RUN setup-oc.sh
+RUN setup-clusteradm.sh
+RUN setup-httpd-tools.sh
+RUN setup-build-harness.sh
+RUN setup-sonar.sh
+RUN setup-node.sh
+RUN setup-yarn.sh /yarn-source
+RUN chmod -R a+rwx /{go,tmp}
+RUN cleanup-node.sh

--- a/build/check-go.sh
+++ b/build/check-go.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+version_json=$(curl https://go.dev/dl/?mode=json)
+parsed_version=$(echo "${version_json}" | jq -r '.[].version' | grep "${GOVERSION%.*}")
+
+if [[ -z "${parsed_version}" ]]; then
+    echo "INFO: Go ${GOVERSION} is no longer supported."
+elif [[ ${parsed_version} != "go${GOVERSION}" ]]; then
+    echo "ERROR: Found Go version '${GOVERSION}', but it's not the latest. Set to GOVERSION to '${parsed_version#go}'."
+    exit 1
+fi

--- a/build/setup-clusteradm.sh
+++ b/build/setup-clusteradm.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -e
+
+module="open-cluster-management.io/clusteradm"
+
+# Get the latest version of clusteradm
+go_mod=$(curl https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/heads/main/go.mod)
+found_module=$(echo "${go_mod}" | awk '/module/ {print $2}')
+
+if [ "${found_module}" != "${module}" ]; then
+    echo "WARN: Currently using clusteradm '${module##*/}'. Found new major version of clusteradm '${found_module##*/}'."
+fi
+
+# Install clusteradm
+GOBIN=/usr/local/bin go install "${module}/cmd/clusteradm@latest"

--- a/build/setup-clusteradm.sh
+++ b/build/setup-clusteradm.sh
@@ -6,7 +6,7 @@ module="open-cluster-management.io/clusteradm"
 
 # Get the latest version of clusteradm
 go_mod=$(curl https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/refs/heads/main/go.mod)
-found_module=$(echo "${go_mod}" | awk '/module/ {print $2}')
+found_module=$(echo "${go_mod}" | awk '/^module/ {print $2}')
 
 if [ "${found_module}" != "${module}" ]; then
     echo "WARN: Currently using clusteradm '${module##*/}'. Found new major version of clusteradm '${found_module##*/}'."

--- a/build/setup-cm-cli.sh
+++ b/build/setup-cm-cli.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -e
+
+# Download cm-cli
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    ARCH="amd64"
+elif [[ "$ARCH" == "aarch64" ]]; then
+    ARCH="arm64"
+fi
+
+wget --progress=dot:mega https://github.com/stolostron/cm-cli/releases/latest/download/cm_${OS}_${ARCH}.tar.gz
+tar -C /tmp -xzf cm_${OS}_${ARCH}.tar.gz
+
+# Spread cm-cli plugin around
+cp /tmp/cm ${GOPATH}/bin/oc-cm
+mv /tmp/cm ${GOPATH}/bin/kubectl-cm
+chmod -R a+rwx ${GOPATH}
+
+# Tidy up
+rm cm_${OS}_${ARCH}.tar.gz

--- a/build/setup-cm-cli.sh
+++ b/build/setup-cm-cli.sh
@@ -11,13 +11,13 @@ elif [[ "$ARCH" == "aarch64" ]]; then
     ARCH="arm64"
 fi
 
-wget --progress=dot:mega https://github.com/stolostron/cm-cli/releases/latest/download/cm_${OS}_${ARCH}.tar.gz
-tar -C /tmp -xzf cm_${OS}_${ARCH}.tar.gz
+wget --progress=dot:giga "https://github.com/stolostron/cm-cli/releases/latest/download/cm_${OS}_${ARCH}.tar.gz"
+tar -C /tmp -xzf "cm_${OS}_${ARCH}.tar.gz"
 
 # Spread cm-cli plugin around
-cp /tmp/cm ${GOPATH}/bin/oc-cm
-mv /tmp/cm ${GOPATH}/bin/kubectl-cm
-chmod -R a+rwx ${GOPATH}
+cp /tmp/cm "${GOPATH}/bin/oc-cm"
+mv /tmp/cm "${GOPATH}/bin/kubectl-cm"
+chmod -R a+rwx "${GOPATH}"
 
 # Tidy up
-rm cm_${OS}_${ARCH}.tar.gz
+rm "cm_${OS}_${ARCH}.tar.gz"

--- a/build/setup-go.sh
+++ b/build/setup-go.sh
@@ -13,7 +13,7 @@ fi
 
 mkdir -p /go/{bin,pkg,src} /go/pkg/cache /opt/go
 cd /opt/go
-wget --progress=dot:mega "https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz"
+wget --progress=dot:giga "https://dl.google.com/go/go${GOVERSION}.${OS}-${ARCH}.tar.gz"
 tar -C /usr/local -xzf "go${GOVERSION}.${OS}-${ARCH}.tar.gz"
 rm -rf /opt/go
 if [ "${ARCH}" = "s390x" ]; then

--- a/build/setup-jq.sh
+++ b/build/setup-jq.sh
@@ -19,7 +19,7 @@ case "${ARCH}" in
                 dnf install -y jq
         ;;
         *)
-                wget "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}" -O /usr/bin/jq
+                wget --progress=dot:giga "https://github.com/jqlang/jq/releases/latest/download/jq-linux-${ARCH}" -O /usr/bin/jq
                 chmod +x /usr/bin/jq
         ;;
 esac

--- a/build/setup-kubebuilder.sh
+++ b/build/setup-kubebuilder.sh
@@ -6,7 +6,7 @@ module="sigs.k8s.io/kubebuilder/v4"
 
 # Get the latest version of kubebuilder
 go_mod=$(curl https://raw.githubusercontent.com/kubernetes-sigs/kubebuilder/refs/heads/master/go.mod)
-found_module=$(echo "${go_mod}" | awk '/module/ {print $2}')
+found_module=$(echo "${go_mod}" | awk '/^module/ {print $2}')
 
 if [ "${found_module}" != "${module}" ]; then
     echo "WARN: Currently using kubebuilder '${module##*/}'. Found new major version of kubebuilder '${found_module##*/}'."

--- a/build/setup-setup-envtest.sh
+++ b/build/setup-setup-envtest.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -e
+
+# Install setup-envtest
+module="sigs.k8s.io/controller-runtime"
+
+# Get the latest version of setup-envtest
+go_mod=$(curl https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/refs/heads/main/go.mod)
+found_module=$(echo "${go_mod}" | awk '/^module/ {print $2}')
+
+if [ "${found_module}" != "${module}" ]; then
+    echo "WARN: Currently using setup-envtest '${module##*/}'. Found new major version of setup-envtest '${found_module##*/}'."
+fi
+
+# Install setup-envtest
+GOBIN=/usr/local/bin go install "${module}/tools/setup-envtest@latest"
+
+# Install latest envtest binaries
+setup-envtest use
+
+# Place binaries in the PATH
+mkdir -p /usr/local/kubebuilder/bin
+cp "$(setup-envtest use -p path)/"* /usr/local/kubebuilder/bin/

--- a/build/setup-sonar.sh
+++ b/build/setup-sonar.sh
@@ -16,7 +16,7 @@ yum clean all
 
 # Install sonar scanner
 cd /opt
-wget --progress=dot:mega "${sonar_url}"
+wget --progress=dot:giga "${sonar_url}"
 unzip "${sonar_file}"
 rm "${sonar_file}"
 mv "${sonar_dir}" sonar

--- a/build/setup-terraform.sh
+++ b/build/setup-terraform.sh
@@ -10,7 +10,7 @@ if [[ "$(uname -m)" == "aarch64" ]]; then
 
     # Pull and extract terraform at the target version in /usr/local/bin
     cd /usr/local/bin
-    wget "https://releases.hashicorp.com/terraform/${LATEST_TF_VERSION}/terraform_${LATEST_TF_VERSION}_linux_arm64.zip"
+    wget --progress=dot:giga "https://releases.hashicorp.com/terraform/${LATEST_TF_VERSION}/terraform_${LATEST_TF_VERSION}_linux_arm64.zip"
     unzip "terraform_${LATEST_TF_VERSION}_linux_arm64.zip"
     chmod +x terraform
     rm -f "terraform_${LATEST_TF_VERSION}_linux_arm64.zip"

--- a/build/setup-yq.sh
+++ b/build/setup-yq.sh
@@ -6,7 +6,7 @@ module="github.com/mikefarah/yq/v4"
 
 # Get the latest version of yq
 go_mod=$(curl https://raw.githubusercontent.com/mikefarah/yq/refs/heads/master/go.mod)
-found_module=$(echo "${go_mod}" | awk '/module/ {print $2}')
+found_module=$(echo "${go_mod}" | awk '/^module/ {print $2}')
 
 if [ "${found_module}" != "${module}" ]; then
     echo "WARN: Currently using yq '${module##*/}'. Found new major version of yq '${found_module##*/}'."


### PR DESCRIPTION
Fixes:
- Restore `cm-cli`; Add `clusteradm` (`cm-cli` was still being used by some squads, so I'll put out an announcement to pivot to `clusteradm`)
- Use writable `/tmp` for `HOME` (this is primarily for Prow where `/tmp` is the recommended writable directory in that environment)

Also:

- Use `dot:giga` for `wget`
- fix: ensure gomod parses module line
- feat: add and seed `setup-envtest` (this also restores binaries to `/usr/local/kubebuilder/bin/`)
- feat: add check for latest Go version
- feat: add NodeJs 22 and 24
